### PR TITLE
Master

### DIFF
--- a/lib/gl.js
+++ b/lib/gl.js
@@ -413,7 +413,7 @@ gl = function () {
   function dumpSpecFile (device, specFile, dumpPath, dumpName) {
     var useSingleDevice = config.getSingleDeviceState() && !config.getSeleniumGrid().enabled;
     var specFileLevels = specFile.split("/");
-    var specFileName = dumpName || specFileLevels[specFileLevels.length -1];
+    var specFileName = dumpName || specFileLevels[specFileLevels.length - 1];
     dumpPage(_drivers[useSingleDevice ? 0 : device.deviceName], specFileName, specFile, dumpPath);
   };
 

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -394,6 +394,25 @@ gl = function () {
   };
 
   /**
+   * Dump a Galen spec file on the current page on a
+   * target driver.
+   *
+   * Argument `specFile` is relative to gl.js, not the test
+   * file.
+   *
+   * @param {Object} device   device specification
+   * @param {String} specFile Galen spec file path
+   */
+  function dumpSpecFile (device, specFile, dumpPath, dumpName) {
+    var useSingleDevice = config.getSingleDeviceState() && !config.getSeleniumGrid().enabled;
+    var specFileLevels = specFile.split("/");
+    var specFileName = dumpName || specFileLevels[specFileLevels.length -1];
+    dumpPage(_drivers[useSingleDevice ? 0 : device.deviceName], specFileName, specFile, dumpPath);
+  };
+
+  /**
+
+  /**
    * Remove all elements stored in cache.
    *
    * Unlikely to be used in tests.

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -405,6 +405,8 @@ gl = function () {
    * Argument `specFile` is relative to gl.js, not the test
    * file.
    *
+   * @see http://galenframework.com/docs/reference-galen-javascript-api/#dumpPage
+   * 
    * @param {Object} device   device specification
    * @param {String} specFile Galen spec file path
    */

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -470,7 +470,7 @@ gl = function () {
   return {
     openPage: openPage,
     runSpecFile: runSpecFile,
-
+    dumpSpecFile: dumpSpecFile,
     quit: quit,
     cleanCache: cleanCache,
 


### PR DESCRIPTION
Enable easy regression-tests with grunt-galen. 

 Galens [dumpPage](http://galenframework.com/docs/reference-galen-javascript-api/#dumpPage) enables the automatic creation of base-images for all the objects of a page for a later visual comperison of those objects with the current state via galens [image](http://galenframework.com/docs/reference-galen-spec-language-guide/#Image).
