### PR TITLE
Bumped galenframework version to 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-galen",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Grunt plugin for Galen",
   "files": [
     "tasks",
@@ -19,7 +19,7 @@
     "node": ">=0.10.0"
   },
   "galen": {
-    "version": "1.6.3"
+    "version": "2.0.5"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Hotfix:
Bumped galen version to 2.0.5 (according to https://github.com/mjurczyk/grunt-galen/pull/12)
Bumped version to 0.5.6
